### PR TITLE
Added Docker-Compose configuration to run the library inside docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/volume/Weighted Edges/*
+/volume/Node Embeddings/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,18 +23,8 @@ COPY ./volume/generate_embeddings.py /app/generate_embeddings.py
 RUN export LIB_PATH=$(python -c "import deepwalk, os; print(os.path.dirname(deepwalk.__file__))") && \
     mv /tmp/___main__.py $LIB_PATH/__main__.py && \
     mv /tmp/weighted_random_walk.py $LIB_PATH/weighted_random_walk.py
-    # mv /tmp/graph.py $LIB_PATH/graph.py
 
-
-# Copy contents of the local src directory to the working directory
-#COPY "./Node Embeddings/" "/app/Node Embeddings/"
-#COPy "./Weighted Edges/" "/app/Weighted Edges/"
-
-# Set the default command
-#   deepwalk --input input.file --format weighted_edgelist --output output.file
-#CMD ["deepwalk", "--input", "/app/Weighted Edges/edges2.txt", "--format", "weighted_edgelist", "--output", "/app/Node Embeddings/edges2.embeddings"]
-#CMD ["sh", "-c", "deepwalk --input '/app/Weighted Edges/edges2.txt' --format weighted_edgelist --output '/app/Node Embeddings/edges2.embeddings' && deepwalk --input '/app/Weighted Edges/edges1.txt' --format weighted_edgelist --output '/app/Node Embeddings/edges1.embeddings'"]
-# Run the python script /app/generate_embeddings.py
+# Run the command to generate the embeddings
 CMD ["python", "/app/generate_embeddings.py"]
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Use an official Python runtime as the base image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+RUN pip install futures==2.1.6
+RUN pip install six
+RUN pip install --upgrade gensim
+RUN pip install psutil
+RUN pip install networkx
+
+# Install the deepwalk package
+RUN pip install deepwalk==1.0.3
+
+# Copy the modified Python files to the container
+COPY ./__main__.py /tmp/___main__.py
+COPY ./weighted_random_walk.py /tmp/weighted_random_walk.py
+COPY ./graph.py /tmp/graph.py
+COPY ./volume/generate_embeddings.py /app/generate_embeddings.py
+
+# Find the deepwalk library path and replace the files
+RUN export LIB_PATH=$(python -c "import deepwalk, os; print(os.path.dirname(deepwalk.__file__))") && \
+    mv /tmp/___main__.py $LIB_PATH/__main__.py && \
+    mv /tmp/weighted_random_walk.py $LIB_PATH/weighted_random_walk.py
+    # mv /tmp/graph.py $LIB_PATH/graph.py
+
+
+# Copy contents of the local src directory to the working directory
+#COPY "./Node Embeddings/" "/app/Node Embeddings/"
+#COPy "./Weighted Edges/" "/app/Weighted Edges/"
+
+# Set the default command
+#   deepwalk --input input.file --format weighted_edgelist --output output.file
+#CMD ["deepwalk", "--input", "/app/Weighted Edges/edges2.txt", "--format", "weighted_edgelist", "--output", "/app/Node Embeddings/edges2.embeddings"]
+#CMD ["sh", "-c", "deepwalk --input '/app/Weighted Edges/edges2.txt' --format weighted_edgelist --output '/app/Node Embeddings/edges2.embeddings' && deepwalk --input '/app/Weighted Edges/edges1.txt' --format weighted_edgelist --output '/app/Node Embeddings/edges1.embeddings'"]
+# Run the python script /app/generate_embeddings.py
+CMD ["python", "/app/generate_embeddings.py"]
+
+
+

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ The deepwalk [1] with weighted edge graph is implemented here.
 
 # Installation: 
 
+## Using docker-compose:
+
+1. Run the following command to build the docker image: 
+
+      `docker-compose build`
+
+## Manual Installation:
+
 1. Install original deepwalk package: 
 
       `pip install deepwalk`
@@ -12,6 +20,16 @@ The deepwalk [1] with weighted edge graph is implemented here.
 2. Move 'main.py' and 'weighted_random_walk.py' into the python lib directory for deepwalk 
 
 # Usage:
+
+## Using docker-compose:
+
+1. Place the Weighted Edges in the volume/Weighted Edges directory.
+
+2. Run the following command to execute the deepwalk with weighted edges:
+
+      `docker-compose up`
+
+## Manual Installation:
 
       deepwalk --input input.file --format weighted_edgelist --output output.file
 

--- a/__main__.py
+++ b/__main__.py
@@ -10,10 +10,10 @@ from collections import Counter
 from concurrent.futures import ProcessPoolExecutor
 import logging
 
-from deepwalk import graph
-from deepwalk import walks as serialized_walks
+from . import graph
+from . import walks as serialized_walks
 from gensim.models import Word2Vec
-from skipgram import Skipgram
+from .skipgram import Skipgram
 
 from six import text_type as unicode
 from six import iteritems
@@ -23,7 +23,7 @@ import psutil
 from multiprocessing import cpu_count
 
 import networkx as nx
-from deepwalk import weighted_random_walk
+from . import weighted_random_walk
 
 p = psutil.Process(os.getpid())
 p.cpu_affinity(list(range(cpu_count())))
@@ -75,9 +75,9 @@ def process(args):
       walks = graph.build_deepwalk_corpus(G, num_paths=args.number_walks,path_length=args.walk_length, alpha=0, rand=random.Random(args.seed))
  
     print("Training...")
-    model = Word2Vec(walks, size=args.representation_size, window=args.window_size, min_count=0, workers=args.workers)
+    model = Word2Vec(walks, vector_size=args.representation_size, window=args.window_size, min_count=0, workers=args.workers)
 
-  model.save_word2vec_format(args.output)
+  model.wv.save_word2vec_format(args.output)
 
 
 def main():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: weighted_deepwalk
+    volumes:
+      - ./volume/Node Embeddings:/app/Node Embeddings
+      - ./volume/Weighted Edges:/app/Weighted Edges

--- a/volume/generate_embeddings.py
+++ b/volume/generate_embeddings.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+def generate_embeddings():
+    files = os.listdir('/app/Weighted Edges')
+    for file in files:
+        if file.endswith('.txt'):
+            os.system(f"deepwalk --input '/app/Weighted Edges/{file}' --format weighted_edgelist --output '/app/Node Embeddings/{file}.embeddings'")
+            print(f"Embeddings generated for {file}")
+
+if __name__ == '__main__':
+    generate_embeddings()

--- a/weighted_random_walk.py
+++ b/weighted_random_walk.py
@@ -3,12 +3,15 @@ import numpy as np
 import random
 
 def getTransitionMatrix(network, nodes):
+	nodes = list(nodes)
 	matrix = np.empty([len(nodes), len(nodes)])
-
+    
 	for i in range(0, len(nodes)):
-		neighs = network.neighbors(nodes[i])
+
+		neighs = network[nodes[i]] # Replaced the above line with this line
 		sums = 0
 		for neigh in neighs:
+			
 			sums += network[nodes[i]][neigh]['weight']
 
 		for j in range(0, len(nodes)):
@@ -40,6 +43,7 @@ def generateSequence(startIndex, transitionMatrix, path_length, alpha):
 
 def random_walk(G, num_paths, path_length, alpha):
 	nodes = G.nodes()
+	nodes = list(nodes)
 	transitionMatrix = getTransitionMatrix(G, nodes)
 
 	sentenceList = []


### PR DESCRIPTION
The library failed to run locally on my MacBook Air M1 due to errors in the deepwalk library installation. This docker config setup helps easily spin up a container to generate embeddings for weighted edges passed to it.

I've changed some lines to fix some errors I encountered while trying to get it running. Need to look into them to ensure they're not breaking changes.